### PR TITLE
Add jekyll docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
 Starter is a barebones starting point for responsive sites built on Jekyll and with
-site management in [prose](http://prose.io). To get started, Fork this repo and [install Jekyll](http://jekyllrb.com/docs/installation).
+site management in [prose](http://prose.io).
+
+Install
+-------
+
+To get started, Fork this repo and [install Jekyll](https://github.com/codeforamerica/howto/blob/master/Jekyll.md).
+
+Contributing
+------------
 
 If you notice any problems or would like to contribute to the project start a discussion from the [issues page](https://github.com/prose/starter/issues)
+


### PR DESCRIPTION
I modified the README to include a link to our Howto guide, which includes background on how to get Ruby.
