### PR TITLE
Make the result more legible and usable when no cases are found

### DIFF
--- a/site.js
+++ b/site.js
@@ -23,7 +23,7 @@ $(document).ready(function() {
 
       var message;
       if (results.length === 0) {
-        message = 'No matching cases found. Please call us at (404) 658-6940.';
+        message = '<strong>No matching cases found. Please call us at <a href="tel:4046586940">(404) 658-6940</href>.</strong>';
       } else if (results.length === 1) {
         message = 'Your case:';
       } else if (results.length <= 9) {


### PR DESCRIPTION
When using this page, I could not tell if there were any results at all. This PR helps to make it a bit more obvious that no cases where found, and also provides a telephone link that is clickable.